### PR TITLE
add default kwargs method for geo_plotly_trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.2] - 2025-03-31
+### Added
+- Added `geo_plotly_trace_default_kwargs` (non-exported) to provide default keyword arguments to `geo_plotly_trace` for custom items (and optionally different for `scatter` and `scattergeo`).
+
 ## [0.1.1] - 2025-03-30
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoPlottingHelpers"
 uuid = "c20ae07a-79b5-4dbd-b2dc-f2e51386613e"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"

--- a/ext/MeshesExt.jl
+++ b/ext/MeshesExt.jl
@@ -18,4 +18,6 @@ GeoPlottingHelpers.geom_iterable(b::Box) = (boundary(b),) # boundary on box retu
 GeoPlottingHelpers.geom_iterable(pol::Union{MultiPolygon,Polygon}) = rings(pol)
 GeoPlottingHelpers.geom_iterable(d::Domain) = d
 
+GeoPlottingHelpers.geo_plotly_trace_default_kwargs(item::Union{Geometry, Domain}, tracefunc) = (; mode = "lines")
+
 end

--- a/ext/PlotlyBaseExt.jl
+++ b/ext/PlotlyBaseExt.jl
@@ -1,17 +1,18 @@
 module PlotlyBaseExt
 
-using GeoPlottingHelpers
+using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords
 using PlotlyBase
 
 function GeoPlottingHelpers.geo_plotly_trace(T::Type{<:AbstractFloat}, tracefunc::Function, item; kwargs...)
+    tracefunc in (scattergeo, scatter) || throw(ArgumentError("The `tracefunc` must be either `scatter` or `scattergeo` from PlotlyBase, while $(tracefunc) was provided"))
+    default_kwargs = geo_plotly_trace_default_kwargs(item, tracefunc)
     (;lon, lat) = extract_latlon_coords(T, item)
-    if tracefunc == scattergeo
-        tracefunc(; lat, lon, kwargs...)
-    elseif tracefunc == scatter
-        tracefunc(; x = lon, y = lat, kwargs...)
+    latlon_kwargs = if tracefunc == scattergeo
+        (; lat, lon)
     else
-        throw(ArgumentError("The `tracefunc` must be either `scatter` or `scattergeo` from PlotlyBase, while $(tracefunc) was provided"))
+        (; x = lon, y = lat)
     end
+    tracefunc(; latlon_kwargs..., default_kwargs..., kwargs...)
 end
 GeoPlottingHelpers.geo_plotly_trace(item; kwargs...) = geo_plotly_trace(scattergeo, item; kwargs...)
 GeoPlottingHelpers.geo_plotly_trace(tracefunc::Function, item; kwargs...) = geo_plotly_trace(Float32, tracefunc, item; kwargs...)

--- a/src/api.jl
+++ b/src/api.jl
@@ -139,3 +139,18 @@ Extracts the lat/lon coordinates from `item` using `extract_latlon_coords(T, ite
 - All the keyword arguments provided are forwarded to the `tracefunc` function.
 """
 function geo_plotly_trace end
+
+"""
+    geo_plotly_trace_default_kwargs(item, tracefunc)
+
+Returns a NamedTuple with the default keyword arguments to feed the `tracefunc` function for the type of `item`.
+The `tracefunc` argument is mandatory when adding methods to this function but is only used for dispatch.
+
+This is used to have some default item specific keyword arguments when calling `geo_plotly_trace`.
+!!! note
+    The default keyword arguments specified with this function can still be overridden by the `kwargs...` passed directly to `geo_plotly_trace`.
+"""
+function geo_plotly_trace_default_kwargs(item, tracefunc)
+    @nospecialize
+    return (;)
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -72,17 +72,20 @@ end
 @testitem "geo_plotly_trace" setup = [setup_api] begin
     b1 = f_box(LatLon(10, 20), LatLon(30, 40))
 
-    tr = geo_plotly_trace(b1; mode = "lines")
+    tr = geo_plotly_trace(b1)
     @test tr isa GenericTrace
     @test tr.type === "scattergeo"
     @test eltype(tr.lat) == Float32
     @test tr.mode === "lines"
 
-    tr = geo_plotly_trace(scatter, b1)
+    tr = geo_plotly_trace(scatter, b1; mode = "markers")
     @test tr.type === "scatter"
+    @test tr.mode === "markers"
 
-    tr = geo_plotly_trace(Float64, scattergeo, b1)
+    pts = boundary(b1) |> vertices
+    tr = geo_plotly_trace(Float64, scattergeo, pts)
     @test eltype(tr.lat) == Float64
+    @test isempty(tr.mode) # We don't have a default for vectors of points
 
     @test_throws "The `tracefunc` must be either `scatter` or `scattergeo`" geo_plotly_trace(heatmap, b1)
 end


### PR DESCRIPTION
This PR adds a method that simplifies customizing default trace kwargs for custom types