### PR TITLE
add coastlines and countries borders via Artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[borders_110m]
+git-tree-sha1 = "f7ea834ce69b56dcc96faad4b44c41be19b1ebe9"
+
+    [[borders_110m.download]]
+    sha256 = "ec3f10f6dc214b0d8dd05bdb3dc179d2228a935c6de0a91c8eb82941aae9f77c"
+    url = "https://github.com/JuliaSatcomFramework/GeoPlottingHelpers.jl/releases/download/v0.1.2/borders_110m.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added the `get_borders_trace_110` and `get_coastlines_trace_110` functions to easily create Plotly traces for the borders and coastlines of countries at 110m resolution.
 
 ## [0.1.2] - 2025-03-31
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,12 @@
 name = "GeoPlottingHelpers"
 uuid = "c20ae07a-79b5-4dbd-b2dc-f2e51386613e"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3-DEV"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [weakdeps]
 CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"
@@ -17,8 +19,10 @@ MeshesExt = "Meshes"
 PlotlyBaseExt = "PlotlyBase"
 
 [compat]
+Artifacts = "1"
 CoordRefSystems = "0.15, 0.16, 0.17"
 Meshes = "0.52, 0.53"
 PlotlyBase = "0.8.20"
 ScopedValues = "1.3.0"
+TOML = "1.0.3"
 julia = "1.10"

--- a/ext/PlotlyBaseExt.jl
+++ b/ext/PlotlyBaseExt.jl
@@ -1,6 +1,6 @@
 module PlotlyBaseExt
 
-using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords
+using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords, get_borders_trace_110, get_coastlines_trace_110
 using PlotlyBase
 
 function GeoPlottingHelpers.geo_plotly_trace(T::Type{<:AbstractFloat}, tracefunc::Function, item; kwargs...)
@@ -16,5 +16,8 @@ function GeoPlottingHelpers.geo_plotly_trace(T::Type{<:AbstractFloat}, tracefunc
 end
 GeoPlottingHelpers.geo_plotly_trace(item; kwargs...) = geo_plotly_trace(scattergeo, item; kwargs...)
 GeoPlottingHelpers.geo_plotly_trace(tracefunc::Function, item; kwargs...) = geo_plotly_trace(Float32, tracefunc, item; kwargs...)
+
+GeoPlottingHelpers.get_borders_trace_110(; kwargs...) = get_borders_trace_110(scattergeo; kwargs...)
+GeoPlottingHelpers.get_coastlines_trace_110(; kwargs...) = get_coastlines_trace_110(scattergeo; kwargs...)
 
 end

--- a/src/GeoPlottingHelpers.jl
+++ b/src/GeoPlottingHelpers.jl
@@ -6,7 +6,7 @@ using Artifacts: Artifacts, @artifact_str
 
 include("constants.jl")
 include("api.jl")
-export with_settings, to_raw_lonlat, extract_latlon_coords, geo_plotly_trace, extract_latlon_coords!, geom_iterable
+export with_settings, to_raw_lonlat, extract_latlon_coords, geo_plotly_trace, extract_latlon_coords!, geom_iterable, get_borders_trace_110, get_coastlines_trace_110
 
 include("helpers.jl")
 

--- a/src/GeoPlottingHelpers.jl
+++ b/src/GeoPlottingHelpers.jl
@@ -1,6 +1,8 @@
 module GeoPlottingHelpers
 
 using ScopedValues: ScopedValues, ScopedValue
+using TOML
+using Artifacts: Artifacts, @artifact_str
 
 include("constants.jl")
 include("api.jl")

--- a/src/api.jl
+++ b/src/api.jl
@@ -210,11 +210,17 @@ function get_borders_trace_110(tracefunc::Function; admin = nothing, kwargs...)
     else
         admin
     end
-    f(key) = get(COUNTRIES_BORDERS_COASTLINES_110, key) do
-        @warn "Country `$key` not found in the list of countries, remember that keys are case sensitive"
-        return nothing
+    function f(key) 
+        if key === "CoastLines"
+            @warn "You provided the `CoastLines` key but coastlines can't be extracted using `get_borders_trace_110`, use `get_coastlines_trace_110` instead"
+            return nothing
+        end
+        return get(COUNTRIES_BORDERS_COASTLINES_110, key) do
+            @warn "Country `$key` not found in the list of countries, remember that keys are case sensitive"
+            return nothing
+        end
     end
-    selected = filter(!isnothing, [f(key) for key in admins if key !== "CoastLines"])
+    selected = filter(!isnothing, [f(key) for key in admins])
     return geo_plotly_trace(tracefunc, selected; BORDERS_DEFAULT_KWARGS..., kwargs...)
 end
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -22,3 +22,6 @@ ScopedValue that contains the settings for `extract_latlon_coords!`. It is a Dic
 Check the docstring of [`with_settings`](@ref) for the possible keys accepted for this Dict.
 """
 const PLOT_SETTINGS = ScopedValue{Dict{Symbol, Any}}(Dict{Symbol, Any}())
+
+const COUNTRIES_BORDERS_COASTLINES_110 = Dict{String, @NamedTuple{lat::Vector{Float32}, lon::Vector{Float32}}}()
+const BORDERS_DEFAULT_KWARGS = (; mode = "lines", line_width = 1, line_color = "black", showlegend = false, hoverinfo = "none")

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -81,3 +81,16 @@ function line_plot_coords(start, stop)
         (f(n) for n in 0:(npts-1))
     end
 end
+
+# This function makes sure that the Dict with borders and coastlines has been loaded
+function ensure_borders_loaded(; force = false)
+    isempty(COUNTRIES_BORDERS_COASTLINES_110) || force || return
+    # We load the dictionary
+    toml_dict = TOML.parsefile(joinpath(artifact"borders_110m", "borders_110m.toml"))
+    for (key, value) in toml_dict
+        lat = map(Float32, value["lat"])
+        lon = map(Float32, value["lon"])
+        COUNTRIES_BORDERS_COASTLINES_110[key] = (; lat, lon)
+    end
+    return nothing
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -109,6 +109,7 @@ end
     @test tr.line_width == 2
 
     @test_logs (:warn, r"not found") get_borders_trace_110(scatter; admin = "spain")
+    @test_logs (:warn, r"can't be extracted") get_borders_trace_110(scatter; admin = "CoastLines")
 end
 
 @testitem "get_coastlines_trace_110" setup = [setup_api] begin

--- a/test/api.jl
+++ b/test/api.jl
@@ -89,3 +89,31 @@ end
 
     @test_throws "The `tracefunc` must be either `scatter` or `scattergeo`" geo_plotly_trace(heatmap, b1)
 end
+
+@testitem "get_borders_trace_110" setup = [setup_api] begin
+    tr = get_borders_trace_110(; line_color = "blue")
+    @test tr isa GenericTrace
+    @test tr.type === "scattergeo"
+    @test tr.line_color == "blue"
+
+    tr = get_borders_trace_110(scatter; admin = ["Italy", "France"])
+    @test tr isa GenericTrace
+    @test tr.type === "scatter"
+    @test tr.mode === "lines"
+    @test tr.line_color == "black"
+
+    tr = get_borders_trace_110(scatter; admin = "Spain", line_width = 2)
+    @test tr isa GenericTrace
+    @test tr.type === "scatter"
+    @test tr.mode === "lines"
+    @test tr.line_width == 2
+
+    @test_logs (:warn, r"not found") get_borders_trace_110(scatter; admin = "spain")
+end
+
+@testitem "get_coastlines_trace_110" setup = [setup_api] begin
+    tr = get_coastlines_trace_110()
+    @test tr isa GenericTrace
+    @test tr.type === "scattergeo"
+    @test eltype(tr.lat) == Float32
+end


### PR DESCRIPTION
Add functionality to easily extract borders of countries or coastlines as a plotly trace, via the two new functions
- `get_borders_trace_110`
- `get_coastlines_trace_110`

These are relying on an Artifact which was created as specified in the release notes of [Release v0.1.2](https://github.com/JuliaSatcomFramework/GeoPlottingHelpers.jl/releases/tag/v0.1.2)