### PR TITLE
Make settings more customizable and add FORCE_ORIENTATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.1.5] - 2025-07-15
+
+### Added
+- Added the possibility of customizing settings also per trace when calling `geo_plotly_trace` or via extending the `GeoPlottingHelpers.geo_plotly_trace_default_kwargs` argument. See docstrings for more details
+- Added a new settings `FORCE_ORIENTATION` to force orientation of points in `Meshes.Ring` to be counterclockwise or clockwise (defaults to keep as is). 
+  - This is useful because when filling polygons within plotly, rings with CCW winding (the defaults for outer rings according to GeoJSON) will actually fill towards the outside, so doing the opposite of what intended
+
 ## [0.1.4] - 2025-07-11
 ### Added
 - Added support for `to_raw_lonlat` for the following inputs:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoPlottingHelpers"
 uuid = "c20ae07a-79b5-4dbd-b2dc-f2e51386613e"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/README.md
+++ b/README.md
@@ -14,4 +14,9 @@ The main user facing functions are:
 - `extract_latlon_coords`: Used to return a NamedTuple which contains just two fields `lat` and `lon` which are vectors that can be used for use in `scattergeo` traces.
 - `geo_plotly_trace`: Which can be used to create either a `scattergeo` or `scatter` trace for plotting geometries/points and relies internally on `extract_latlon_coords`.
 
+Some details on how latlon coords are extracted can be tweaked thanks to the `with_settings` function, and lastly, adding custom extraction of latlon and custom plotting for specific types can be obtained by adding custom methods to the following functions (not all needed, check respective docstrings):
+- `geom_iterable`
+- `to_raw_lonlat`
+- `geo_plotly_trace_default_kwargs`
+
 Check the docstrings for more details.

--- a/ext/GeoPlottingHelpersMeshesExt.jl
+++ b/ext/GeoPlottingHelpersMeshesExt.jl
@@ -2,13 +2,26 @@ module GeoPlottingHelpersMeshesExt
 
 using Meshes
 using GeoPlottingHelpers
-using GeoPlottingHelpers: CLOSE_VECTORS, ScopedValues
 
 GeoPlottingHelpers.to_raw_lonlat(p::Point) = to_raw_lonlat(coords(p))
 
+function force_orientation(r::Ring)
+    sym = GeoPlottingHelpers.force_orientation()
+    o = orientation(r)
+    if sym === :CW
+        return o === CW ? r : reverse(r)
+    elseif sym === :CCW
+        return o === CCW ? r : reverse(r)
+    else
+        return r
+    end
+end
+
 function GeoPlottingHelpers.extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, ring::Ring) where T <: AbstractFloat
+    # We potentially force the orientation of the ring, depending on settings.
+    ring = force_orientation(ring)
     # We plot the points in the ring
-    ScopedValues.with(CLOSE_VECTORS => true) do
+    with_settings((; CLOSE_VECTORS = true)) do
         GeoPlottingHelpers.extract_latlon_coords!(lat, lon, vertices(ring))
     end
     return nothing
@@ -19,5 +32,4 @@ GeoPlottingHelpers.geom_iterable(pol::Union{MultiPolygon,Polygon}) = rings(pol)
 GeoPlottingHelpers.geom_iterable(d::Domain) = d
 
 GeoPlottingHelpers.geo_plotly_trace_default_kwargs(item::Union{Geometry, Domain}, tracefunc) = (; mode = "lines")
-
 end

--- a/ext/GeoPlottingHelpersPlotlyBaseExt.jl
+++ b/ext/GeoPlottingHelpersPlotlyBaseExt.jl
@@ -1,18 +1,29 @@
 module GeoPlottingHelpersPlotlyBaseExt
 
-using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords, get_borders_trace_110, get_coastlines_trace_110
+using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords, get_borders_trace_110, get_coastlines_trace_110, PLOT_SETTINGS, with_settings
 using PlotlyBase
 
 function GeoPlottingHelpers.geo_plotly_trace(T::Type{<:AbstractFloat}, tracefunc::Function, item; kwargs...)
     tracefunc in (scattergeo, scatter) || throw(ArgumentError("The `tracefunc` must be either `scatter` or `scattergeo` from PlotlyBase, while $(tracefunc) was provided"))
     default_kwargs = geo_plotly_trace_default_kwargs(item, tracefunc)
-    (;lon, lat) = extract_latlon_coords(T, item)
+    nt_kwargs = (; default_kwargs..., kwargs...)
+    # We try to extract custom per-trace settings. We have both settings_dict and settings_nt depending on priority of the settings. NamedTuple settings have lower priority
+    settings_dict = @something get(nt_kwargs, :settings_dict, nothing) PLOT_SETTINGS[] # This falls back to the existing high priority settings
+    settings_nt = @something get(nt_kwargs, :settings_nt, nothing) (;) # This falls back to empty NamedTuple which is using low priority default values
+    (;lon, lat) = with_settings(settings_dict) do
+        with_settings(settings_nt) do
+            extract_latlon_coords(T, item)
+        end
+    end
+    # We remove settings from the kwargs as they are not needed for plotly
+    valid_keys = setdiff(keys(nt_kwargs), (:settings_dict, :settings_nt)) |> Tuple
+    nt_kwargs = NamedTuple{valid_keys}(nt_kwargs)
     latlon_kwargs = if tracefunc == scattergeo
         (; lat, lon)
     else
         (; x = lon, y = lat)
     end
-    tracefunc(; latlon_kwargs..., default_kwargs..., kwargs...)
+    tracefunc(; latlon_kwargs..., nt_kwargs...)
 end
 GeoPlottingHelpers.geo_plotly_trace(item; kwargs...) = geo_plotly_trace(scattergeo, item; kwargs...)
 GeoPlottingHelpers.geo_plotly_trace(tracefunc::Function, item; kwargs...) = geo_plotly_trace(Float32, tracefunc, item; kwargs...)

--- a/src/GeoPlottingHelpers.jl
+++ b/src/GeoPlottingHelpers.jl
@@ -5,8 +5,12 @@ using TOML
 using Artifacts: Artifacts, @artifact_str
 
 include("constants.jl")
+
+include("settings.jl")
+export with_settings
+
 include("api.jl")
-export with_settings, to_raw_lonlat, extract_latlon_coords, geo_plotly_trace, extract_latlon_coords!, geom_iterable, get_borders_trace_110, get_coastlines_trace_110
+export to_raw_lonlat, extract_latlon_coords, geo_plotly_trace, extract_latlon_coords!, geom_iterable, get_borders_trace_110, get_coastlines_trace_110
 
 include("helpers.jl")
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,28 +1,3 @@
-# These are internal ScopedValues used to control the behavior of `extract_latlon_coords!`. They are mirrored by keys of the same name in the `PLOT_SETTINGS` Dict which is also a ScopedValue and should be from users to control the behavior of `extract_latlon_coords!`.
-# Specify whether to insert NaN before each vector of points within the lat/lon vectors
-const INSERT_NAN = ScopedValue{Bool}(true)
-#= 
-Specify whether `extract_latlon_coords!` should potentially add artificial points between each pair of input points in order to have lines appear straight on scattergeo plots. This can have a symbol and three valid values (In reality, every symbol that is not the first two will be treated as `:NONE`)
-- `:NORMAL` will add artificial points only when necessary (when distance between points is too large) and will create lines that never cross the antimeridian. This is useful for example to plot Box geometries with large areas and have them still look like boxes.
-- `:SHORT` will add artificial points like per `:NORMAL` but will also make sure the line drawn between the points is the shortest one (potentially crossing the antimeridian at 180° longitude).
-- `:NONE` will not add artificial points
-=#
-const OVERSAMPLE_LINES = ScopedValue{Symbol}(:NONE)
-const PLOT_STRAIGHT_LINES = OVERSAMPLE_LINES
-#= 
-Specify whether to close the vector of points by repeating the first point at the end of the vector.
-=#
-const CLOSE_VECTORS = ScopedValue{Bool}(false)
-
-"""
-    PLOT_SETTINGS
-
-ScopedValue that contains the settings for `extract_latlon_coords!`. It is a Dict with keys as symbol which can be used to customize the behavior of `extract_latlon_coords!`.
-
-Check the docstring of [`with_settings`](@ref) for the possible keys accepted for this Dict.
-"""
-const PLOT_SETTINGS = ScopedValue{Dict{Symbol, Any}}(Dict{Symbol, Any}())
-
 const COUNTRIES_BORDERS_COASTLINES_110 = Dict{String, @NamedTuple{lat::Vector{Float32}, lon::Vector{Float32}}}()
 const BORDERS_DEFAULT_KWARGS = (; mode = "lines", line_width = 1, line_color = "black", showlegend = false, hoverinfo = "none")
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,13 +1,14 @@
 
 # These are internal function used to parse the settings to customize the behavior of `extract_latlon_coords!`.
-should_insert_nan() = get(PLOT_SETTINGS[], :INSERT_NAN, INSERT_NAN[])
+should_insert_nan() = get(PLOT_SETTINGS[], :INSERT_NAN, NT_SETTINGS.INSERT_NAN[][])
 should_shorten_lines() = get(PLOT_SETTINGS[], :OVERSAMPLE_LINES) do 
-    get(PLOT_SETTINGS[], :PLOT_STRAIGHT_LINES, OVERSAMPLE_LINES[])
+    get(PLOT_SETTINGS[], :PLOT_STRAIGHT_LINES, NT_SETTINGS.OVERSAMPLE_LINES[][])
 end === :SHORT
 should_oversample_points() = get(PLOT_SETTINGS[], :OVERSAMPLE_LINES) do
-    get(PLOT_SETTINGS[], :PLOT_STRAIGHT_LINES, OVERSAMPLE_LINES[])
-end  ∈ (:SHORT, :NORMAL)
-should_close_vectors() = get(PLOT_SETTINGS[], :CLOSE_VECTORS, CLOSE_VECTORS[])
+    get(PLOT_SETTINGS[], :PLOT_STRAIGHT_LINES, NT_SETTINGS.OVERSAMPLE_LINES[][])
+end ∈ (:SHORT, :NORMAL)
+should_close_vectors() = get(PLOT_SETTINGS[], :CLOSE_VECTORS, NT_SETTINGS.CLOSE_VECTORS[][])
+force_orientation() = get(PLOT_SETTINGS[], :FORCE_ORIENTATION, NT_SETTINGS.FORCE_ORIENTATION[][])
 
 """
     is_valid_point(p)

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1,0 +1,86 @@
+#= 
+These are internal ScopedValues used to control the behavior of `extract_latlon_coords!`. They are mirrored by keys of the same name in the `PLOT_SETTINGS` Dict which is also a ScopedValue and should be from users to control the behavior of `extract_latlon_coords!`.
+
+Each of these settings will control the behvior of `extract_latlon_coords!`.
+
+- INSERT_NAN: Specify whether to insert NaN before each vector of points within the lat/lon vectors
+- OVERSAMPLE_LINES: Specify whether `extract_latlon_coords!` should potentially add artificial points between each pair of input points in order to have lines appear straight on scattergeo plots. This can have a symbol and three valid values (In reality, every symbol that is not the first two will be treated as `:NONE`)
+  - `:NORMAL` will add artificial points only when necessary (when distance between points is too large) and will create lines that never cross the antimeridian. This is useful for example to plot Box geometries with large areas and have them still look like boxes.
+  - `:SHORT` will add artificial points like per `:NORMAL` but will also make sure the line drawn between the points is the shortest one (potentially crossing the antimeridian at 180° longitude).
+  - `:NONE` will not add artificial points
+- CLOSE_VECTORS: Specify whether to close the vector of points by repeating the first point at the end of the vector.
+- FORCE_ORIENTATION: Specify whether to force the orientation of the rings of points. This is useful as when filling polygons (with `fill="toself"`), plotly expects rings to be oriented clockwise. Possible options are:
+  - `:NONE` will not force the orientation of the rings of points.
+  - `:CW` will force the orientation of the rings of points to be clockwise.
+  - `:CCW` will force the orientation of the rings of points to be counter-clockwise.
+=#
+const NT_SETTINGS = (;
+    INSERT_NAN = ScopedValue{Base.RefValue{Bool}}(Ref(true)),
+    OVERSAMPLE_LINES = ScopedValue{Base.RefValue{Symbol}}(Ref(:NONE)),
+    CLOSE_VECTORS = ScopedValue{Base.RefValue{Bool}}(Ref(false)),
+    FORCE_ORIENTATION = ScopedValue{Base.RefValue{Symbol}}(Ref(:NONE)),
+)
+
+# This is a map of the names of the settings in the `NT_SETTINGS`. It is mostly needed as some settings are aliases of others (currently only `PLOT_STRAIGHT_LINES` is an alias of `OVERSAMPLE_LINES`).
+const SETTINGS_NAMES_MAP = (;
+    INSERT_NAN = :INSERT_NAN,
+    OVERSAMPLE_LINES = :OVERSAMPLE_LINES,
+    PLOT_STRAIGHT_LINES = :OVERSAMPLE_LINES,
+    CLOSE_VECTORS = :CLOSE_VECTORS,
+    FORCE_ORIENTATION = :FORCE_ORIENTATION,
+)
+
+# This is a Dict with the same settings as NT_SETTINGS but this will take priority and is what most users will set when using `with_settings`.
+const PLOT_SETTINGS = ScopedValue{Dict{Symbol, Any}}(Dict{Symbol, Any}())
+
+"""
+    with_settings(f, settings::Pair{Symbol, <:Any}...)
+
+Convenience function to change settings for plotting, and specifically for how `extract_latlon_coords!` will behave. It expects pairs of symbol as keys and values depending on the setting as explained below
+
+The possible keys that can be provided as settings are:
+- `:INSERT_NAN => Bool`: Specify whether to insert NaN before each vector of points within the lat/lon vectors.
+- `:OVERSAMPLE_LINES => Symbol`: Specify whether `extract_latlon_coords!` should potentially add artificial points between each pair of input points in order to have lines appear straight on scattergeo plots. This can have a symbol and three valid values (In reality, every symbol that is not the first two will be treated as `:NONE`)
+  - `:NORMAL` will add artificial points only when necessary (when distance between points is too large) and will create lines that never cross the antimeridian. This is useful for example to plot Box geometries with large areas and have them still look like boxes.
+  - `:SHORT` will add artificial points like per `:NORMAL` but will also make sure the line drawn between the points is the shortest one (potentially crossing the antimeridian at 180° longitude).
+  - `:NONE` will not add artificial points
+- `:PLOT_STRAIGHT_LINES => Symbol`: This is just an alias for the `:OVERSAMPLE_LINES` key and they have the same effect. Note: `:OVERSAMPLE_LINES` has higher priority if both keys are provided.
+- `:CLOSE_VECTORS => Bool`: Specify whether to close any vector of points by repeating the first point at the end of the vector.
+- `:FORCE_ORIENTATION => Symbol`: Specify whether to force the orientation of the rings of points. This is useful as when filling polygons (with `fill="toself"`), plotly expects rings to be oriented clockwise. Possible options are:
+  - `:NONE` will not force the orientation of the rings of points.
+  - `:CW` will force the orientation of the rings of points to be clockwise.
+  - `:CCW` will force the orientation of the rings of points to be counter-clockwise.
+
+# Example
+```julia
+using GeoPlottingHelpers
+
+with_settings(:PLOT_STRAIGHT_LINES => :NORMAL) do
+    geo_plotly_trace(geometry) # This will oversample lines to make them appear straight on scattergeo plots. Only for the commands within the `with_settings` block.
+end
+```
+"""
+with_settings(f, settings::AbstractVector) = with_settings(f, settings...)
+with_settings(f, settings::Pair{Symbol,<:Any}...) = with_settings(f, Dict(settings...))
+function with_settings(f, settings::Dict{Symbol,<:Any})
+    ScopedValues.with(PLOT_SETTINGS => settings) do
+        f()
+    end
+end
+# This is mostly internal, when passing a NamedTuple this will be used to overwrite the settings in the `NT_SETTINGS` with the values in the NamedTuple. It is useful when trying have default settings in trace default kwargs that are still going to be overriden if the user creates a `with_settings` block explicitly
+function with_settings(f, settings::NamedTuple)
+    # Check if unsupported settings were provided
+    setdiff(keys(settings), keys(SETTINGS_NAMES_MAP)) |> isempty || @warn("Unsupported settings were provided and will be ignored: $(setdiff(keys(settings), keys(SETTINGS_NAMES_MAP)))\nThe following keys are supported: $(keys(SETTINGS_NAMES_MAP))")
+    # We process the provided settings to translate the given values into pairs to use with ScopedValues.with
+    ps = Pair{<:ScopedValue}[]
+    for (k, v) in pairs(settings)
+        k in keys(SETTINGS_NAMES_MAP) || continue
+        mapped_key = SETTINGS_NAMES_MAP[k]
+        sv = NT_SETTINGS[mapped_key]
+        R = typeof(sv[])
+        push!(ps, sv => R(v))
+    end
+    ScopedValues.with(ps...) do
+        f()
+    end
+end

--- a/test/settings.jl
+++ b/test/settings.jl
@@ -8,7 +8,7 @@ end
 @testitem "with_settings" setup = [setup_settings] begin
     r = rand(Ring; crs = LatLon)
     r_cw = orientation(r) === CW ? r : reverse(r) # Force this to be CW
-    r_ccw = reverse(r)
+    r_ccw = reverse(r_cw)
     ll = extract_latlon_coords(r_cw)
     # We test that by default the orientation is not forced
     llr = extract_latlon_coords(r_ccw)

--- a/test/settings.jl
+++ b/test/settings.jl
@@ -1,0 +1,33 @@
+@testsnippet setup_settings begin
+    using CoordRefSystems
+    using Meshes
+    using PlotlyBase
+    using GeoPlottingHelpers: with_settings, should_close_vectors, should_insert_nan, force_orientation, should_shorten_lines, NT_SETTINGS
+end
+
+@testitem "with_settings" setup = [setup_settings] begin
+    r = rand(Ring; crs = LatLon)
+    r_cw = orientation(r) === CW ? r : reverse(r) # Force this to be CW
+    r_ccw = reverse(r)
+    ll = extract_latlon_coords(r_cw)
+    # We test that by default the orientation is not forced
+    llr = extract_latlon_coords(r_ccw)
+    @test ll.lat == reverse(llr.lat) && ll.lon == reverse(llr.lon)
+    # We test forcing the orientation to be CCW
+    with_settings(:FORCE_ORIENTATION => :CCW) do
+        @test extract_latlon_coords(r_cw) == llr
+    end
+
+    # We test that settings provided as NamedTuple are lower priority than the one provided as Dict
+    with_settings(:FORCE_ORIENTATION => :CCW) do
+        with_settings((; FORCE_ORIENTATION = :CW)) do # This is inner but lower priority
+            @test extract_latlon_coords(r_cw) == llr
+        end
+    end
+
+    # Test that passing custom settings to the trace is respected
+    @test geo_plotly_trace(r_cw).lat == ll.lat # This is the reference behavior without custom settings
+    @test geo_plotly_trace(r_cw; settings_nt = (; FORCE_ORIENTATION = :CCW)).lat == llr.lat # This is the reference behavior without custom settings
+    # We test that if both dict and settings are provided, the dict ones are used
+    @test geo_plotly_trace(r_cw; settings_nt = (; FORCE_ORIENTATION = :CCW), settings_dict = Dict(:FORCE_ORIENTATION => :CW)).lat == ll.lat # This is the reference behavior without custom settings
+end


### PR DESCRIPTION
This PR brings the following changes:
- Added the possibility of customizing settings also per trace when calling `geo_plotly_trace` or via extending the `GeoPlottingHelpers.geo_plotly_trace_default_kwargs` argument. See docstrings for more details
- Added a new settings `FORCE_ORIENTATION` to force orientation of points in `Meshes.Ring` to be counterclockwise or clockwise (defaults to keep as is). 
  - This is useful because when filling polygons within plotly, rings with CCW winding (the defaults for outer rings according to GeoJSON) will actually fill towards the outside, so doing the opposite of what intended