### PR TITLE
make `extract_lonlat_coords` more consistent with the intended API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.6] - 2025-08-21
+
+### Changed
+- Refactored the method of `extract_latlon_coords` taking a vector as input to be more consistent with the intended API.
+
+### Fixed
+- Fixed `extract_latlon_coords` not respecting various settings (e.g. `OVERSAMPLE_LINES`, `CLOSE_VECTORS`) when fed a vector of different types all satisfying the `is_valid_point` interface.
+  - This only used to work when checking `is_valid_point` on the `eltype` of the input vector, thus failing for vectors of heterogeneous types.
+
 ## [0.1.5] - 2025-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed `extract_latlon_coords` not respecting various settings (e.g. `OVERSAMPLE_LINES`, `CLOSE_VECTORS`) when fed a vector of different types all satisfying the `is_valid_point` interface.
   - This only used to work when checking `is_valid_point` on the `eltype` of the input vector, thus failing for vectors of heterogeneous types.
+- Stopped `get_borders_trace_110` from always printing a wrong warning when called with default keyword arguments.
 
 ## [0.1.5] - 2025-07-15
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoPlottingHelpers"
 uuid = "c20ae07a-79b5-4dbd-b2dc-f2e51386613e"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ GeoPlottingHelpersUnitfulExt = "Unitful"
 [compat]
 Artifacts = "1"
 CoordRefSystems = "0.16 - 0.18"
-Meshes = "0.52, 0.53"
+Meshes = "0.52 - 0.54"
 PlotlyBase = "0.8.20"
 ScopedValues = "1.3.0"
 TOML = "1.0.3"

--- a/src/GeoPlottingHelpers.jl
+++ b/src/GeoPlottingHelpers.jl
@@ -6,12 +6,13 @@ using Artifacts: Artifacts, @artifact_str
 
 include("constants.jl")
 
+include("helpers.jl")
+
 include("settings.jl")
 export with_settings
 
 include("api.jl")
 export to_raw_lonlat, extract_latlon_coords, geo_plotly_trace, extract_latlon_coords!, geom_iterable, get_borders_trace_110, get_coastlines_trace_110
 
-include("helpers.jl")
 
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -105,7 +105,7 @@ struct PairIterator{V <: AbstractVector}
 end
 
 # Iterator interface
-Base.length(iter::PairIterator) = length(iter.wrapped)
+Base.length(iter::PairIterator) = return length(iter.wrapped)
 Base.eltype(::PairIterator{V}) where V = return Pair{eltype(V), eltype(V)}
 
 function Base.iterate(iter::PairIterator, state = 1)

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -10,6 +10,9 @@ end ∈ (:SHORT, :NORMAL)
 should_close_vectors() = get(PLOT_SETTINGS[], :CLOSE_VECTORS, NT_SETTINGS.CLOSE_VECTORS[][])
 force_orientation() = get(PLOT_SETTINGS[], :FORCE_ORIENTATION, NT_SETTINGS.FORCE_ORIENTATION[][])
 
+# For should_insert_nan we also add a method that takes lat and lon vectors and also checks if they are empty
+should_insert_nan(lat::AbstractVector, lon::AbstractVector) = return should_insert_nan() && !isempty(lat) && !isempty(lon)
+
 """
     is_valid_point(p)
 
@@ -95,3 +98,27 @@ function ensure_borders_loaded(; force = false)
     end
     return nothing
 end
+
+# This is an helper struct to iterate over pair of consecutive elements within a vector, always return as last element the pair between the last and the first element
+struct PairIterator{V <: AbstractVector}
+    wrapped::V
+end
+
+# Iterator interface
+Base.length(iter::PairIterator) = length(iter.wrapped)
+Base.eltype(::PairIterator{V}) where V = return Pair{eltype(V), eltype(V)}
+
+function Base.iterate(iter::PairIterator, state = 1)
+    L = length(iter)
+    state <= L || return nothing
+    (; wrapped) = iter
+    item = if state == L
+        wrapped[end] => wrapped[1]
+    else
+        wrapped[state] => wrapped[state + 1]
+    end
+    return item, state + 1
+end
+
+
+

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,0 +1,11 @@
+@testitem "PairIterator" begin
+    using Test
+    using GeoPlottingHelpers: PairIterator
+
+    @test length(PairIterator([1,2,3])) == 3
+    @test length(PairIterator([1,2,3,4])) == 4
+
+    @test eltype(PairIterator([1,2,3])) == Pair{Int, Int}
+
+    @test collect(PairIterator([1,2,3])) == [(1 => 2), (2 => 3), (3 => 1)]
+end


### PR DESCRIPTION
### Changed
- Refactored the method of `extract_latlon_coords` taking a vector as input to be more consistent with the intended API.

### Fixed
- Fixed `extract_latlon_coords` not respecting various settings (e.g. `OVERSAMPLE_LINES`, `CLOSE_VECTORS`) when fed a vector of different types all satisfying the `is_valid_point` interface.
  - This only used to work when checking `is_valid_point` on the `eltype` of the input vector, thus failing for vectors of heterogeneous types.
- Stopped `get_borders_trace_110` from always printing a wrong warning when called with default keyword arguments.