### PR TITLE
refactor great circle code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [0.1.8] - 2025-08-26
+### Fixed
+- Fixed a typo/error in the `antimeridian_crossing_great_circle` function.
+- Refactored the internals of the great circle crossing computations to be more flexible in the input types.
+
+## [0.1.8] - 2025-08-26
 ### Changed
 - Updated the `geom_iterable` method for `Multi` (before it was only defined for `MultiPolygon`) to allow generic auto plotting of `Multi`s.
-
 
 ## [0.1.7] - 2025-08-26
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoPlottingHelpers"
 uuid = "c20ae07a-79b5-4dbd-b2dc-f2e51386613e"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -2,20 +2,32 @@
     using Test
     using GeoPlottingHelpers: PairIterator
 
-    @test length(PairIterator([1,2,3])) == 3
-    @test length(PairIterator([1,2,3,4])) == 4
+    @test length(PairIterator([1, 2, 3])) == 3
+    @test length(PairIterator([1, 2, 3, 4])) == 4
 
-    @test eltype(PairIterator([1,2,3])) == Pair{Int, Int}
+    @test eltype(PairIterator([1, 2, 3])) == Pair{Int,Int}
 
-    @test collect(PairIterator([1,2,3])) == [(1 => 2), (2 => 3), (3 => 1)]
+    @test collect(PairIterator([1, 2, 3])) == [(1 => 2), (2 => 3), (3 => 1)]
 end
 
 @testitem "Great Circle crossing" begin
-    using GeoPlottingHelpers: crossing_latitude_great_circle, slerp
+    using GeoPlottingHelpers: crossing_latitude_great_circle, slerp, lonlat_to_xyz, antimeridian_crossing_great_circle, dot
 
     p1 = (150, 20)
     p2 = (-150, 20)
     pt = slerp(p1, p2, 0.5)
     gc_lat = crossing_latitude_great_circle(p1, p2)
-    @test pt[2] ≈ gc_lat atol=1e-6
+    @test pt[2] ≈ gc_lat atol = 1e-6
+
+    # We test slightly different by extracting the corresponding `t` from the intersection to use slerp
+    p1 = (-103.177, 27.569)
+    p2 = (155.896, -33.4032)
+    a = lonlat_to_xyz(p1)
+    b = lonlat_to_xyz(p2)
+    intersection = antimeridian_crossing_great_circle(a, b)
+    # We can find the normalized distance between p1 and the intersection by finding the ratio in the angle betwwen a and intersection over the angle between a and b. This works because the intersection is by design lying on the plane containing the great circle arc between a and b.
+    t = acos(dot(a, intersection)) / acos(dot(a, b))
+    pt = slerp(p1, p2, t)
+    gc_lat = crossing_latitude_great_circle(p1, p2)
+    @test pt[2] ≈ gc_lat atol = 1e-6
 end


### PR DESCRIPTION
This PR fixes a bug in the great circle crossing computation and refactors the internal code to be more flexible in terms of accepted inputs.

It also adds a test showing how to compute the fractional distance between the antimeridian crossing and the starting point to be used in the `slerp` computation