### PR TITLE
Add NAN_AS_NOTHING setting for JSON-safe PlotlyBase serialization

### DIFF
--- a/ext/GeoPlottingHelpersPlotlyBaseExt.jl
+++ b/ext/GeoPlottingHelpersPlotlyBaseExt.jl
@@ -1,6 +1,6 @@
 module GeoPlottingHelpersPlotlyBaseExt
 
-using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords, get_borders_trace_110, get_coastlines_trace_110, PLOT_SETTINGS, with_settings
+using GeoPlottingHelpers: GeoPlottingHelpers, geo_plotly_trace, geo_plotly_trace_default_kwargs, extract_latlon_coords, get_borders_trace_110, get_coastlines_trace_110, PLOT_SETTINGS, with_settings, nan_as_nothing
 using PlotlyBase
 
 function GeoPlottingHelpers.geo_plotly_trace(T::Type{<:AbstractFloat}, tracefunc::Function, item; kwargs...)
@@ -10,9 +10,16 @@ function GeoPlottingHelpers.geo_plotly_trace(T::Type{<:AbstractFloat}, tracefunc
     # We try to extract custom per-trace settings. We have both settings_dict and settings_nt depending on priority of the settings. NamedTuple settings have lower priority
     settings_dict = @something get(nt_kwargs, :settings_dict, nothing) PLOT_SETTINGS[] # This falls back to the existing high priority settings
     settings_nt = @something get(nt_kwargs, :settings_nt, nothing) (;) # This falls back to empty NamedTuple which is using low priority default values
+    _nan_to_nothing(x::AbstractFloat) = isnan(x) ? nothing : x
+    _nan_to_nothing(x) = x
     (;lon, lat) = with_settings(settings_dict) do
         with_settings(settings_nt) do
-            extract_latlon_coords(T, item)
+            ll = extract_latlon_coords(T, item)
+            if nan_as_nothing()
+                (lat = map(_nan_to_nothing, ll.lat), lon = map(_nan_to_nothing, ll.lon))
+            else
+                ll
+            end
         end
     end
     # We remove settings from the kwargs as they are not needed for plotly

--- a/src/api.jl
+++ b/src/api.jl
@@ -20,7 +20,7 @@ If a method for this function is implemented for a custom type, GeoPlottingHelpe
 function geom_iterable end
 
 """
-    extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, item)
+    extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, item) where T<:AbstractFloat
 
 Extract the lat/lon coordinates out of `item` and append them to the `lat` and `lon` vectors which are assumed to represent values in degrees.
 
@@ -30,7 +30,7 @@ The behavior of this function can be customized by using the [`PLOT_SETTINGS`](@
 
 See also: [`extract_latlon_coords`](@ref), [`geom_iterable`](@ref), [`to_raw_lonlat`](@ref), [`with_settings`](@ref)
 """
-function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, item)
+function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, item) where T<:AbstractFloat
     if is_iterable_geometry(item)
         for geom in geom_iterable(item)
             extract_latlon_coords!(lat, lon, geom)
@@ -45,7 +45,7 @@ function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothin
     return nothing
 end
 
-function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, v::AbstractVector)
+function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, v::AbstractVector) where T<:AbstractFloat
     previous_point = false
     should_close = should_close_vectors() && all(is_valid_point, v)
     for (n, pair) in enumerate(PairIterator(v))
@@ -53,8 +53,7 @@ function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothin
         if is_valid_point(p)
             if !previous_point && should_insert_nan(lat, lon)
                 # Every time we have a point which was not preceded by another point we insert NaNs if the setting is enabled
-                sep = nan_as_nothing() ? nothing : NaN
-                push!(lat, sep); push!(lon, sep)
+                extract_latlon_coords!(lat, lon, (NaN, NaN))
             end
             if should_oversample_points() && is_valid_point(pnext)
                 # We do eventual straightening only between couples of consecutive points
@@ -86,10 +85,9 @@ function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothin
 end
 
 # This is useful to join together outputs of extract_latlon_coords
-function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, v::Union{@NamedTuple{lat::Vector{F}, lon::Vector{F}}, @NamedTuple{lon::Vector{F}, lat::Vector{F}}}) where {F<:AbstractFloat}
+function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, v::Union{@NamedTuple{lat::Vector{F}, lon::Vector{F}}, @NamedTuple{lon::Vector{F}, lat::Vector{F}}}) where {T<:AbstractFloat, F<:AbstractFloat}
     if should_insert_nan() && !isempty(lat) && !isempty(lon)
-        sep = nan_as_nothing() ? nothing : NaN
-        push!(lat, sep); push!(lon, sep)
+        extract_latlon_coords!(lat, lon, (NaN, NaN))
     end
     append!(lat, v.lat)
     append!(lon, v.lon)
@@ -104,9 +102,8 @@ Returns a NamedTuple with two vectors `lat` and `lon` containing the correspondi
 This is mostly intended to simplify creation of the `lat` and `lon` keyword arguments to provide to the `scattergeo` function from `PlotlyBase`. By default points are converted to Float32 and NaN values are inserted between each separate vector of points to allow plotting multiple geometries within a single trace.
 """
 function extract_latlon_coords(T::Type{<:AbstractFloat}, item)
-    ET = nan_as_nothing() ? Union{T, Nothing} : T
-    lat = ET[]
-    lon = ET[]
+    lat = T[]
+    lon = T[]
     extract_latlon_coords!(lat, lon, item)
     return (; lat, lon)
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -20,7 +20,7 @@ If a method for this function is implemented for a custom type, GeoPlottingHelpe
 function geom_iterable end
 
 """
-    extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, item) where T<:AbstractFloat
+    extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, item)
 
 Extract the lat/lon coordinates out of `item` and append them to the `lat` and `lon` vectors which are assumed to represent values in degrees.
 
@@ -30,7 +30,7 @@ The behavior of this function can be customized by using the [`PLOT_SETTINGS`](@
 
 See also: [`extract_latlon_coords`](@ref), [`geom_iterable`](@ref), [`to_raw_lonlat`](@ref), [`with_settings`](@ref)
 """
-function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, item) where T<:AbstractFloat
+function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, item)
     if is_iterable_geometry(item)
         for geom in geom_iterable(item)
             extract_latlon_coords!(lat, lon, geom)
@@ -45,7 +45,7 @@ function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, item) where T<:A
     return nothing
 end
 
-function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, v::AbstractVector) where T<:AbstractFloat
+function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, v::AbstractVector)
     previous_point = false
     should_close = should_close_vectors() && all(is_valid_point, v)
     for (n, pair) in enumerate(PairIterator(v))
@@ -53,7 +53,8 @@ function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, v::AbstractVecto
         if is_valid_point(p)
             if !previous_point && should_insert_nan(lat, lon)
                 # Every time we have a point which was not preceded by another point we insert NaNs if the setting is enabled
-                extract_latlon_coords!(lat, lon, (NaN, NaN))
+                sep = nan_as_nothing() ? nothing : NaN
+                push!(lat, sep); push!(lon, sep)
             end
             if should_oversample_points() && is_valid_point(pnext)
                 # We do eventual straightening only between couples of consecutive points
@@ -85,9 +86,10 @@ function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, v::AbstractVecto
 end
 
 # This is useful to join together outputs of extract_latlon_coords
-function extract_latlon_coords!(lat::Vector{T}, lon::Vector{T}, v::Union{@NamedTuple{lat::Vector{F}, lon::Vector{F}}, @NamedTuple{lon::Vector{F}, lat::Vector{F}}}) where {T<:AbstractFloat, F<:AbstractFloat}
+function extract_latlon_coords!(lat::AbstractVector{<:Union{AbstractFloat,Nothing}}, lon::AbstractVector{<:Union{AbstractFloat,Nothing}}, v::Union{@NamedTuple{lat::Vector{F}, lon::Vector{F}}, @NamedTuple{lon::Vector{F}, lat::Vector{F}}}) where {F<:AbstractFloat}
     if should_insert_nan() && !isempty(lat) && !isempty(lon)
-        extract_latlon_coords!(lat, lon, (NaN, NaN))
+        sep = nan_as_nothing() ? nothing : NaN
+        push!(lat, sep); push!(lon, sep)
     end
     append!(lat, v.lat)
     append!(lon, v.lon)
@@ -102,8 +104,9 @@ Returns a NamedTuple with two vectors `lat` and `lon` containing the correspondi
 This is mostly intended to simplify creation of the `lat` and `lon` keyword arguments to provide to the `scattergeo` function from `PlotlyBase`. By default points are converted to Float32 and NaN values are inserted between each separate vector of points to allow plotting multiple geometries within a single trace.
 """
 function extract_latlon_coords(T::Type{<:AbstractFloat}, item)
-    lat = T[]
-    lon = T[]
+    ET = nan_as_nothing() ? Union{T, Nothing} : T
+    lat = ET[]
+    lon = ET[]
     extract_latlon_coords!(lat, lon, item)
     return (; lat, lon)
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -9,6 +9,7 @@ should_oversample_points() = get(PLOT_SETTINGS[], :OVERSAMPLE_LINES) do
 end ∈ (:SHORT, :NORMAL)
 should_close_vectors() = get(PLOT_SETTINGS[], :CLOSE_VECTORS, NT_SETTINGS.CLOSE_VECTORS[][])
 force_orientation() = get(PLOT_SETTINGS[], :FORCE_ORIENTATION, NT_SETTINGS.FORCE_ORIENTATION[][])
+nan_as_nothing() = get(PLOT_SETTINGS[], :NAN_AS_NOTHING, NT_SETTINGS.NAN_AS_NOTHING[][])
 
 # For should_insert_nan we also add a method that takes lat and lon vectors and also checks if they are empty
 should_insert_nan(lat::AbstractVector, lon::AbstractVector) = return should_insert_nan() && !isempty(lat) && !isempty(lon)

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1,4 +1,4 @@
-#= 
+#=
 These are internal ScopedValues used to control the behavior of `extract_latlon_coords!`. They are mirrored by keys of the same name in the `PLOT_SETTINGS` Dict which is also a ScopedValue and should be from users to control the behavior of `extract_latlon_coords!`.
 
 Each of these settings will control the behvior of `extract_latlon_coords!`.
@@ -13,12 +13,14 @@ Each of these settings will control the behvior of `extract_latlon_coords!`.
   - `:NONE` will not force the orientation of the rings of points.
   - `:CW` will force the orientation of the rings of points to be clockwise.
   - `:CCW` will force the orientation of the rings of points to be counter-clockwise.
+- NAN_AS_NOTHING: Specify whether separator NaN values should be emitted as `nothing` instead of `NaN`. When true, the output lat/lon vectors will have element type `Union{T, Nothing}` rather than `T`. This is useful for JSON serialization (e.g. PlotlyBase → JS) where NaN is not a valid JSON value.
 =#
 const NT_SETTINGS = (;
     INSERT_NAN = ScopedValue{Base.RefValue{Bool}}(Ref(true)),
     OVERSAMPLE_LINES = ScopedValue{Base.RefValue{Symbol}}(Ref(:NONE)),
     CLOSE_VECTORS = ScopedValue{Base.RefValue{Bool}}(Ref(false)),
     FORCE_ORIENTATION = ScopedValue{Base.RefValue{Symbol}}(Ref(:NONE)),
+    NAN_AS_NOTHING = ScopedValue{Base.RefValue{Bool}}(Ref(false)),
 )
 
 # This is a map of the names of the settings in the `NT_SETTINGS`. It is mostly needed as some settings are aliases of others (currently only `PLOT_STRAIGHT_LINES` is an alias of `OVERSAMPLE_LINES`).
@@ -28,6 +30,7 @@ const SETTINGS_NAMES_MAP = (;
     PLOT_STRAIGHT_LINES = :OVERSAMPLE_LINES,
     CLOSE_VECTORS = :CLOSE_VECTORS,
     FORCE_ORIENTATION = :FORCE_ORIENTATION,
+    NAN_AS_NOTHING = :NAN_AS_NOTHING,
 )
 
 # This is a Dict with the same settings as NT_SETTINGS but this will take priority and is what most users will set when using `with_settings`.
@@ -50,6 +53,7 @@ The possible keys that can be provided as settings are:
   - `:NONE` will not force the orientation of the rings of points.
   - `:CW` will force the orientation of the rings of points to be clockwise.
   - `:CCW` will force the orientation of the rings of points to be counter-clockwise.
+- `:NAN_AS_NOTHING => Bool`: When `true`, separator NaN values inserted between geometry segments are emitted as `nothing` instead of `NaN`, producing `Vector{Union{T, Nothing}}` lat/lon vectors. Defaults to `false`. Useful for JSON serialization (e.g. PlotlyBase → JS) where NaN is not a valid JSON value.
 
 # Example
 ```julia

--- a/test/settings.jl
+++ b/test/settings.jl
@@ -2,7 +2,7 @@
     using CoordRefSystems
     using Meshes
     using PlotlyBase
-    using GeoPlottingHelpers: with_settings, should_close_vectors, should_insert_nan, force_orientation, should_shorten_lines, NT_SETTINGS
+    using GeoPlottingHelpers: with_settings, should_close_vectors, should_insert_nan, force_orientation, should_shorten_lines, nan_as_nothing, NT_SETTINGS
 end
 
 @testitem "with_settings" setup = [setup_settings] begin
@@ -30,4 +30,44 @@ end
     @test geo_plotly_trace(r_cw; settings_nt = (; FORCE_ORIENTATION = :CCW)).lat == llr.lat # This is the reference behavior without custom settings
     # We test that if both dict and settings are provided, the dict ones are used
     @test geo_plotly_trace(r_cw; settings_nt = (; FORCE_ORIENTATION = :CCW), settings_dict = Dict(:FORCE_ORIENTATION => :CW)).lat == ll.lat # This is the reference behavior without custom settings
+end
+
+@testitem "NAN_AS_NOTHING setting" setup = [setup_settings] begin
+    r1 = rand(Ring; crs = LatLon)
+    r2 = rand(Ring; crs = LatLon)
+
+    # extract_latlon_coords always returns plain float vectors regardless of NAN_AS_NOTHING
+    @test nan_as_nothing() == false
+    ll = extract_latlon_coords([r1, r2])
+    @test eltype(ll.lat) <: AbstractFloat
+    @test any(isnan, ll.lat)
+
+    with_settings(:NAN_AS_NOTHING => true) do
+        @test nan_as_nothing() == true
+        ll = extract_latlon_coords([r1, r2])
+        @test eltype(ll.lat) <: AbstractFloat  # unaffected — still plain floats with NaN
+        @test any(isnan, ll.lat)
+    end
+
+    # geo_plotly_trace replaces `NaN` with `nothing` when NAN_AS_NOTHING = true
+    ll_trace = geo_plotly_trace([r1, r2]; settings_dict = Dict(:NAN_AS_NOTHING => true))
+    @test any(isnothing, ll_trace.lat)
+    @test all(x -> isnothing(x) || !isnan(x), ll_trace.lat)
+
+    # Default geo_plotly_trace still produces NaN separators
+    ll_trace_default = geo_plotly_trace([r1, r2])
+    @test any(isnan, ll_trace_default.lat)
+    @test !any(isnothing, ll_trace_default.lat)
+
+    # NAN_AS_NOTHING via settings_nt keyword (lower priority than settings_dict)
+    ll_trace_nt = geo_plotly_trace([r1, r2]; settings_nt = (; NAN_AS_NOTHING = true))
+    @test any(isnothing, ll_trace_nt.lat)
+
+    # settings_dict takes priority over settings_nt
+    ll_trace_prio = geo_plotly_trace([r1, r2]; settings_nt = (; NAN_AS_NOTHING = true), settings_dict = Dict(:NAN_AS_NOTHING => false))
+    @test any(isnan, ll_trace_prio.lat)
+    @test !any(isnothing, ll_trace_prio.lat)
+
+    # Setting reverts to default outside with_settings block
+    @test nan_as_nothing() == false
 end


### PR DESCRIPTION
### Motivation

PlotlyBase serializes trace data to JSON for rendering in the browser. JSON does not permit `NaN` values, which means the `NaN` separators that `GeoPlottingHelpers` inserts between geometry segments can cause serialization errors or silent failures when traces are sent to a JavaScript frontend.

### What changed

**New setting: `:NAN_AS_NOTHING => Bool`** (defaults to `false`)

When set to `true`, `geo_plotly_trace` replaces any `NaN` values in the `lat` and `lon` vectors with `nothing` before constructing the trace. The resulting vectors have element type `Union{T, Nothing}`, which PlotlyBase serializes as `null` — a valid JSON value that Plotly.js interprets correctly as a gap between line segments.

```julia
# All existing code is unaffected by default
geo_plotly_trace(geometry)

# Opt in to JSON-safe output
geo_plotly_trace(geometry; settings_dict = Dict(:NAN_AS_NOTHING => true))

# Or via with_settings for a whole block
with_settings(:NAN_AS_NOTHING => true) do
    geo_plotly_trace(geometry)
end
```
### Design note

The NaN→nothing transformation is intentionally applied only inside geo_plotly_trace, not in extract_latlon_coords. This keeps coordinate extraction as a pure float concern — extract_latlon_coords always returns Vector{T<:AbstractFloat} regardless of the setting.

